### PR TITLE
Fix #include statements, don't inhibit compiler warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC_x64 := gcc
 STRIP := strip
-OPTIONS := -O3 -I include -w -ldl
+OPTIONS := -O3 -I include -ldl
 OBJECTS := procmem.o utils.o
 
 all: apollon-all-x64 apollon-selective-x64

--- a/src/apollon.c
+++ b/src/apollon.c
@@ -1,3 +1,6 @@
+#include <unistd.h>
+#include <string.h>
+
 #include "../include/utils.h"
 #include "../include/procmem.h"
 #include "../include/shellcode.h"

--- a/src/procmem.c
+++ b/src/procmem.c
@@ -1,5 +1,5 @@
-#include <stdio.h>
-#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
 
 #include "../include/utils.h"
 #include "../include/procmem.h"


### PR DESCRIPTION
Building for amd64 with GCC 12.2.0 (Debian/bookworm) produced a binary that would segfault after writing
```
[+] Searching for pattern […] in data segment of […]
```
to the console.

Inspection with gdb revealed that `strtok()` calls returned only the lower 32 bits of the pointer. This happened because the compiler had not known about the function's definition and assumed that it returned an int instead of a pointer… which we would have seen if compiler warnings had not been silenced.

